### PR TITLE
Fix xacro invocation in launch files

### DIFF
--- a/launch/launch_sim_simple.launch.py
+++ b/launch/launch_sim_simple.launch.py
@@ -14,7 +14,7 @@ def generate_launch_description():
         "robot.urdf.xacro"
     ])
 
-    robot_description = Command(['xacro ', robot_description_path])
+    robot_description = Command(['xacro', robot_description_path])
 
     return LaunchDescription([
         Node(

--- a/launch/rsp.launch.py
+++ b/launch/rsp.launch.py
@@ -17,7 +17,7 @@ def generate_launch_description():
     xacro_file = os.path.join(pkg_path, 'description', 'robot.urdf.xacro')
 
     robot_description_config = ParameterValue(
-        Command(['xacro ', xacro_file, ' use_ros2_control:=', use_ros2_control, ' sim_mode:=', use_sim_time]),
+        Command(['xacro', xacro_file, ' use_ros2_control:=', use_ros2_control, ' sim_mode:=', use_sim_time]),
         value_type=str
     )
 


### PR DESCRIPTION
## Summary
- fix `Command` invocation by removing trailing spaces before `xacro`

## Testing
- `python -m py_compile launch/launch_sim_simple.launch.py launch/rsp.launch.py`

------
https://chatgpt.com/codex/tasks/task_e_683fc3391e408327a1c3ebc608fc2e15