### PR TITLE
Fix missing entry point for image processing node

### DIFF
--- a/vision/image_processing.py
+++ b/vision/image_processing.py
@@ -30,3 +30,7 @@ def main(args=None):
     rclpy.spin(node)
     node.destroy_node()
     rclpy.shutdown()
+    cv2.destroyAllWindows()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add missing `if __name__ == "__main__"` entry point to `image_processing.py`
- ensure GUI windows are closed on shutdown

## Testing
- `python -m py_compile vision/image_processing.py`
- `colcon test --packages-select lipan --event-handlers console_cohesion+ --return-code-on-test-failure` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fc3534fe8832783493690b368084a