### PR TITLE
Fix navigation launch argument typo

### DIFF
--- a/launch/navigation_launch.py
+++ b/launch/navigation_launch.py
@@ -96,7 +96,7 @@ def generate_launch_description():
 
     declare_container_name_cmd = DeclareLaunchArgument(
         'container_name', default_value='nav2_container',
-        description='the name of conatiner that nodes will load in if use composition')
+        description='the name of container that nodes will load in if use composition')
 
     declare_use_respawn_cmd = DeclareLaunchArgument(
         'use_respawn', default_value='False',


### PR DESCRIPTION
## Summary
- fix a typo in `navigation_launch.py` description

## Testing
- `python3 -m py_compile launch/navigation_launch.py`


------
https://chatgpt.com/codex/tasks/task_e_6846a12a4ff88327820ddd3f1ba9b326